### PR TITLE
Add gRPC module for NucleoDB CRUD operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,8 @@ repositories {
     }
 }
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
-    }
-}
-compileJava {
-    options.release = 19
+    sourceCompatibility = JavaVersion.VERSION_19
+    targetCompatibility = JavaVersion.VERSION_19
 }
 
 test {

--- a/nucleodb-grpc/build.gradle
+++ b/nucleodb-grpc/build.gradle
@@ -1,0 +1,79 @@
+plugins {
+    id 'java'
+    id 'com.google.protobuf' version '0.9.4'
+}
+
+group = 'com.nucleodb'
+version = '1.19.2.1'
+
+repositories {
+    mavenCentral()
+    maven {
+        name = 'SynloadRepo'
+        url = uri("https://nexus.synload.com/repository/maven-repo-releases/")
+        credentials {
+            username = System.getenv("SYNLOAD_REPO_USER")
+            password = System.getenv("SYNLOAD_REPO_PASS")
+        }
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_19
+    targetCompatibility = JavaVersion.VERSION_19
+}
+
+// gRPC version compatible with ratis-grpc:3.1.2 (uses grpc 1.56.x)
+def grpcVersion = '1.56.1'
+def protobufVersion = '3.23.4'
+
+dependencies {
+    implementation project(':')
+
+    implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
+    implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+    implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-services:${grpcVersion}"
+
+    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+
+    // Required for @Generated annotation in Java 9+
+    compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation "org.mockito:mockito-core:5.12.0"
+    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${protobufVersion}"
+    }
+    plugins {
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+        }
+    }
+    generateProtoTasks {
+        all()*.plugins {
+            grpc {}
+        }
+    }
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs 'build/generated/source/proto/main/grpc'
+            srcDirs 'build/generated/source/proto/main/java'
+        }
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/NucleoDBGrpcServer.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/NucleoDBGrpcServer.java
@@ -1,0 +1,59 @@
+package com.nucleodb.grpc;
+
+import io.grpc.Server;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class NucleoDBGrpcServer {
+    private static final Logger logger =
+        Logger.getLogger(NucleoDBGrpcServer.class.getName());
+
+    private final Server server;
+    private final int port;
+
+    NucleoDBGrpcServer(Server server, int port) {
+        this.server = server;
+        this.port = port;
+    }
+
+    public void start() throws IOException {
+        server.start();
+        logger.info("NucleoDB gRPC server started on port " + port);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            logger.info("Shutting down gRPC server...");
+            try {
+                NucleoDBGrpcServer.this.stop();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            logger.info("gRPC server shut down.");
+        }));
+    }
+
+    public void stop() throws InterruptedException {
+        if (server != null) {
+            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
+    public void blockUntilShutdown() throws InterruptedException {
+        if (server != null) {
+            server.awaitTermination();
+        }
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public Server getServer() {
+        return server;
+    }
+
+    public static NucleoDBGrpcServerBuilder builder() {
+        return new NucleoDBGrpcServerBuilder();
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/NucleoDBGrpcServerBuilder.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/NucleoDBGrpcServerBuilder.java
@@ -1,0 +1,63 @@
+package com.nucleodb.grpc;
+
+import com.nucleodb.grpc.service.ConnectionService;
+import com.nucleodb.grpc.service.DataEntryService;
+import com.nucleodb.library.NucleoDB;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
+import io.grpc.protobuf.services.ProtoReflectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NucleoDBGrpcServerBuilder {
+
+    private NucleoDB nucleoDB;
+    private int port = 9090;
+    private boolean enableReflection = true;
+    private final List<ServerInterceptor> interceptors = new ArrayList<>();
+
+    NucleoDBGrpcServerBuilder() {}
+
+    public NucleoDBGrpcServerBuilder nucleoDB(NucleoDB nucleoDB) {
+        this.nucleoDB = nucleoDB;
+        return this;
+    }
+
+    public NucleoDBGrpcServerBuilder port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public NucleoDBGrpcServerBuilder enableReflection(boolean enable) {
+        this.enableReflection = enable;
+        return this;
+    }
+
+    public NucleoDBGrpcServerBuilder addInterceptor(ServerInterceptor interceptor) {
+        this.interceptors.add(interceptor);
+        return this;
+    }
+
+    public NucleoDBGrpcServer build() {
+        if (nucleoDB == null) {
+            throw new IllegalStateException("NucleoDB instance is required");
+        }
+
+        ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port)
+            .addService(new DataEntryService(nucleoDB))
+            .addService(new ConnectionService(nucleoDB));
+
+        if (enableReflection) {
+            serverBuilder.addService(ProtoReflectionService.newInstance());
+        }
+
+        for (ServerInterceptor interceptor : interceptors) {
+            serverBuilder.intercept(interceptor);
+        }
+
+        Server server = serverBuilder.build();
+        return new NucleoDBGrpcServer(server, port);
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/service/ConnectionService.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/service/ConnectionService.java
@@ -1,0 +1,499 @@
+package com.nucleodb.grpc.service;
+
+import com.nucleodb.grpc.proto.*;
+import com.nucleodb.grpc.util.JsonHelper;
+import com.nucleodb.grpc.util.StatusHelper;
+import com.nucleodb.library.NucleoDB;
+import com.nucleodb.library.database.tables.connection.Connection;
+import com.nucleodb.library.database.tables.connection.ConnectionHandler;
+import com.nucleodb.library.database.tables.connection.ConnectionProjection;
+import com.nucleodb.library.database.tables.table.DataEntry;
+import com.nucleodb.library.database.utils.Pagination;
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ConnectionService extends ConnectionServiceGrpc.ConnectionServiceImplBase {
+    private static final Logger logger = Logger.getLogger(ConnectionService.class.getName());
+
+    private final NucleoDB nucleoDB;
+
+    public ConnectionService(NucleoDB nucleoDB) {
+        this.nucleoDB = nucleoDB;
+    }
+
+    private ConnectionHandler<?> resolveHandler(String connectionType) {
+        return nucleoDB.getConnections().get(connectionType.toUpperCase());
+    }
+
+    private DataEntry<?> stubEntry(String key) {
+        return new DataEntry<>(key);
+    }
+
+    @Override
+    public void create(CreateConnectionRequest request,
+                       StreamObserver<CreateConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(CreateConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type '" + request.getConnectionType() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Connection connection = (Connection) handler.getConfig()
+                .getConnectionClass().getDeclaredConstructor().newInstance();
+            connection.setFromKey(request.getFromKey());
+            connection.setToKey(request.getToKey());
+            if (request.getMetadataMap() != null && !request.getMetadataMap().isEmpty()) {
+                connection.getMetadata().putAll(request.getMetadataMap());
+            }
+
+            handler.saveSync(connection);
+
+            responseObserver.onNext(CreateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setConnection(JsonHelper.toProto(connection))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection Create", e);
+            responseObserver.onNext(CreateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void get(GetConnectionRequest request,
+                    StreamObserver<GetConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(GetConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type '" + request.getConnectionType() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Connection connection = (Connection) handler
+                .getConnectionByUUID().get(request.getUuid());
+            if (connection == null) {
+                responseObserver.onNext(GetConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_NOT_FOUND,
+                        "Connection '" + request.getUuid() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            responseObserver.onNext(GetConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setConnection(JsonHelper.toProto(connection))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection Get", e);
+            responseObserver.onNext(GetConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getByFrom(GetConnectionsByFromRequest request,
+                          StreamObserver<GetConnectionsByFromResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(GetConnectionsByFromResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type '" + request.getConnectionType() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            ConnectionProjection projection = new ConnectionProjection<>();
+            if (request.hasPagination()) {
+                projection = new ConnectionProjection<>(new Pagination(
+                    request.getPagination().getSkip(),
+                    request.getPagination().getLimit()));
+            }
+
+            Set<Connection> connections = handler.getByFrom(
+                stubEntry(request.getFromKey()), projection);
+
+            GetConnectionsByFromResponse.Builder resp =
+                GetConnectionsByFromResponse.newBuilder()
+                    .setStatus(StatusHelper.success());
+
+            if (connections != null) {
+                for (Connection conn : connections) {
+                    resp.addConnections(JsonHelper.toProto(conn));
+                }
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection GetByFrom", e);
+            responseObserver.onNext(GetConnectionsByFromResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getByFromAndTo(GetConnectionsByFromAndToRequest request,
+                               StreamObserver<GetConnectionsByFromAndToResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(GetConnectionsByFromAndToResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            ConnectionProjection projection = new ConnectionProjection<>();
+            if (request.hasPagination()) {
+                projection = new ConnectionProjection<>(new Pagination(
+                    request.getPagination().getSkip(),
+                    request.getPagination().getLimit()));
+            }
+
+            Set<Connection> connections = handler.getByFromAndTo(
+                stubEntry(request.getFromKey()),
+                stubEntry(request.getToKey()),
+                projection);
+
+            GetConnectionsByFromAndToResponse.Builder resp =
+                GetConnectionsByFromAndToResponse.newBuilder()
+                    .setStatus(StatusHelper.success());
+
+            if (connections != null) {
+                for (Connection conn : connections) {
+                    resp.addConnections(JsonHelper.toProto(conn));
+                }
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection GetByFromAndTo", e);
+            responseObserver.onNext(GetConnectionsByFromAndToResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getByTo(GetConnectionsByToRequest request,
+                        StreamObserver<GetConnectionsByToResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(GetConnectionsByToResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            ConnectionProjection projection = new ConnectionProjection<>();
+            if (request.hasPagination()) {
+                projection = new ConnectionProjection<>(new Pagination(
+                    request.getPagination().getSkip(),
+                    request.getPagination().getLimit()));
+            }
+
+            Set<Connection> connections = handler.getReverseByTo(
+                stubEntry(request.getToKey()), projection);
+
+            GetConnectionsByToResponse.Builder resp =
+                GetConnectionsByToResponse.newBuilder()
+                    .setStatus(StatusHelper.success());
+
+            if (connections != null) {
+                for (Connection conn : connections) {
+                    resp.addConnections(JsonHelper.toProto(conn));
+                }
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection GetByTo", e);
+            responseObserver.onNext(GetConnectionsByToResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getAll(GetAllConnectionsRequest request,
+                       StreamObserver<GetAllConnectionsResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(GetAllConnectionsResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            long totalCount = handler.getAllConnections().size();
+
+            ConnectionProjection projection = new ConnectionProjection<>();
+            if (request.hasPagination()) {
+                projection = new ConnectionProjection<>(new Pagination(
+                    request.getPagination().getSkip(),
+                    request.getPagination().getLimit()));
+            }
+
+            Set<Connection> connections = handler.get(projection);
+
+            GetAllConnectionsResponse.Builder resp =
+                GetAllConnectionsResponse.newBuilder()
+                    .setStatus(StatusHelper.success())
+                    .setTotalCount(totalCount);
+
+            if (connections != null) {
+                for (Connection conn : connections) {
+                    resp.addConnections(JsonHelper.toProto(conn));
+                }
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection GetAll", e);
+            responseObserver.onNext(GetAllConnectionsResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void update(UpdateConnectionRequest request,
+                       StreamObserver<UpdateConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(UpdateConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Connection original = (Connection) handler
+                .getConnectionByUUID().get(request.getUuid());
+            if (original == null) {
+                responseObserver.onNext(UpdateConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_NOT_FOUND,
+                        "Connection '" + request.getUuid() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Connection copy = original.copy(
+                handler.getConfig().getConnectionClass(), false);
+
+            if (request.getMetadataMap() != null) {
+                copy.getMetadata().clear();
+                copy.getMetadata().putAll(request.getMetadataMap());
+            }
+
+            handler.saveSync(copy);
+
+            responseObserver.onNext(UpdateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setConnection(JsonHelper.toProto(copy))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection Update", e);
+            responseObserver.onNext(UpdateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void delete(DeleteConnectionRequest request,
+                       StreamObserver<DeleteConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(DeleteConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Connection connection = (Connection) handler
+                .getConnectionByUUID().get(request.getUuid());
+            if (connection == null) {
+                responseObserver.onNext(DeleteConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_NOT_FOUND,
+                        "Connection '" + request.getUuid() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            handler.deleteSync(connection);
+
+            responseObserver.onNext(DeleteConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection Delete", e);
+            responseObserver.onNext(DeleteConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void bulkCreate(BulkCreateConnectionRequest request,
+                           StreamObserver<BulkCreateConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(BulkCreateConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            List<ConnectionMessage> created = new ArrayList<>();
+            int successCount = 0;
+            int failureCount = 0;
+
+            for (CreateConnectionEntry entry : request.getConnectionsList()) {
+                try {
+                    Connection conn = (Connection) handler.getConfig()
+                        .getConnectionClass().getDeclaredConstructor().newInstance();
+                    conn.setFromKey(entry.getFromKey());
+                    conn.setToKey(entry.getToKey());
+                    if (entry.getMetadataMap() != null) {
+                        conn.getMetadata().putAll(entry.getMetadataMap());
+                    }
+                    handler.saveSync(conn);
+                    created.add(JsonHelper.toProto(conn));
+                    successCount++;
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Bulk connection create item failed", e);
+                    failureCount++;
+                }
+            }
+
+            responseObserver.onNext(BulkCreateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success(
+                    successCount + " created, " + failureCount + " failed"))
+                .addAllConnections(created)
+                .setSuccessCount(successCount)
+                .setFailureCount(failureCount)
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection BulkCreate", e);
+            responseObserver.onNext(BulkCreateConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void bulkDelete(BulkDeleteConnectionRequest request,
+                           StreamObserver<BulkDeleteConnectionResponse> responseObserver) {
+        try {
+            ConnectionHandler handler = resolveHandler(request.getConnectionType());
+            if (handler == null) {
+                responseObserver.onNext(BulkDeleteConnectionResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.CONNECTION_TYPE_NOT_FOUND,
+                        "Connection type not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            int successCount = 0;
+            int failureCount = 0;
+
+            for (String uuid : request.getUuidsList()) {
+                try {
+                    Connection conn = (Connection) handler
+                        .getConnectionByUUID().get(uuid);
+                    if (conn != null) {
+                        handler.deleteSync(conn);
+                        successCount++;
+                    } else {
+                        failureCount++;
+                    }
+                } catch (Exception e) {
+                    logger.log(Level.WARNING,
+                        "Bulk connection delete failed for uuid: " + uuid, e);
+                    failureCount++;
+                }
+            }
+
+            responseObserver.onNext(BulkDeleteConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.success(
+                    successCount + " deleted, " + failureCount + " failed"))
+                .setSuccessCount(successCount)
+                .setFailureCount(failureCount)
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Connection BulkDelete", e);
+            responseObserver.onNext(BulkDeleteConnectionResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/service/DataEntryService.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/service/DataEntryService.java
@@ -1,0 +1,441 @@
+package com.nucleodb.grpc.service;
+
+import com.nucleodb.grpc.proto.*;
+import com.nucleodb.grpc.util.JsonHelper;
+import com.nucleodb.grpc.util.StatusHelper;
+import com.nucleodb.library.NucleoDB;
+import com.nucleodb.library.database.tables.table.DataEntry;
+import com.nucleodb.library.database.tables.table.DataEntryProjection;
+import com.nucleodb.library.database.tables.table.DataTable;
+import com.nucleodb.library.database.utils.Pagination;
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DataEntryService extends DataEntryServiceGrpc.DataEntryServiceImplBase {
+    private static final Logger logger = Logger.getLogger(DataEntryService.class.getName());
+
+    private final NucleoDB nucleoDB;
+
+    public DataEntryService(NucleoDB nucleoDB) {
+        this.nucleoDB = nucleoDB;
+    }
+
+    @Override
+    public void create(CreateDataEntryRequest request,
+                       StreamObserver<CreateDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(CreateDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Class<?> dataClass = table.getConfig().getClazz();
+            Object dataObj = JsonHelper.mapper().readValue(request.getDataJson(), dataClass);
+
+            Class<?> deClass = table.getConfig().getDataEntryClass();
+            DataEntry entry;
+            if (deClass == DataEntry.class) {
+                entry = new DataEntry(dataObj);
+            } else {
+                entry = (DataEntry) deClass.getDeclaredConstructor(dataClass)
+                    .newInstance(dataObj);
+            }
+
+            table.saveSync(entry);
+
+            responseObserver.onNext(CreateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setEntry(JsonHelper.toProto(entry))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Create", e);
+            responseObserver.onNext(CreateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void get(GetDataEntryRequest request,
+                    StreamObserver<GetDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(GetDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Set<DataEntry> entries = table.get("id", request.getKey(), null);
+            if (entries == null || entries.isEmpty()) {
+                responseObserver.onNext(GetDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.ENTRY_NOT_FOUND,
+                        "Entry '" + request.getKey() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            DataEntry entry = entries.iterator().next();
+            responseObserver.onNext(GetDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setEntry(JsonHelper.toProto(entry))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Get", e);
+            responseObserver.onNext(GetDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getByIndex(GetDataEntriesByIndexRequest request,
+                           StreamObserver<GetDataEntriesByIndexResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(GetDataEntriesByIndexResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Object value = JsonHelper.mapper().readValue(request.getValueJson(), Object.class);
+
+            DataEntryProjection projection = new DataEntryProjection();
+            if (request.hasPagination()) {
+                projection = new DataEntryProjection(new Pagination(
+                    request.getPagination().getSkip(),
+                    request.getPagination().getLimit()));
+            }
+
+            Set<DataEntry> entries = table.get(request.getIndexKey(), value, projection);
+
+            GetDataEntriesByIndexResponse.Builder resp =
+                GetDataEntriesByIndexResponse.newBuilder()
+                    .setStatus(StatusHelper.success());
+
+            if (entries != null) {
+                for (DataEntry entry : entries) {
+                    resp.addEntries(JsonHelper.toProto(entry));
+                }
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in GetByIndex", e);
+            responseObserver.onNext(GetDataEntriesByIndexResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void getAll(GetAllDataEntriesRequest request,
+                       StreamObserver<GetAllDataEntriesResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(GetAllDataEntriesResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Set<DataEntry> allEntries = table.getEntries();
+            long totalCount = allEntries.size();
+
+            long skip = 0, limit = 50;
+            if (request.hasPagination()) {
+                skip = request.getPagination().getSkip();
+                limit = request.getPagination().getLimit();
+            }
+
+            GetAllDataEntriesResponse.Builder resp =
+                GetAllDataEntriesResponse.newBuilder()
+                    .setStatus(StatusHelper.success())
+                    .setTotalCount(totalCount);
+
+            long count = 0;
+            long skipped = 0;
+            for (DataEntry entry : allEntries) {
+                if (skipped < skip) {
+                    skipped++;
+                    continue;
+                }
+                if (count >= limit) break;
+                resp.addEntries(JsonHelper.toProto(entry));
+                count++;
+            }
+
+            responseObserver.onNext(resp.build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in GetAll", e);
+            responseObserver.onNext(GetAllDataEntriesResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void update(UpdateDataEntryRequest request,
+                       StreamObserver<UpdateDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(UpdateDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            DataEntryProjection projection = new DataEntryProjection();
+            projection.setWritable(true);
+            Set<DataEntry> entries = table.get("id", request.getKey(), projection);
+
+            if (entries == null || entries.isEmpty()) {
+                responseObserver.onNext(UpdateDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.ENTRY_NOT_FOUND,
+                        "Entry '" + request.getKey() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            DataEntry entryCopy = entries.iterator().next();
+
+            Class<?> dataClass = table.getConfig().getClazz();
+            Object newData = JsonHelper.mapper().readValue(request.getDataJson(), dataClass);
+            entryCopy.setData(newData);
+
+            table.saveSync(entryCopy);
+
+            responseObserver.onNext(UpdateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setEntry(JsonHelper.toProto(entryCopy))
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Update", e);
+            responseObserver.onNext(UpdateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void delete(DeleteDataEntryRequest request,
+                       StreamObserver<DeleteDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(DeleteDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            DataEntryProjection projection = new DataEntryProjection();
+            projection.setWritable(true);
+            Set<DataEntry> entries = table.get("id", request.getKey(), projection);
+
+            if (entries == null || entries.isEmpty()) {
+                responseObserver.onNext(DeleteDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.ENTRY_NOT_FOUND,
+                        "Entry '" + request.getKey() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            DataEntry entry = entries.iterator().next();
+            table.deleteSync(entry);
+
+            responseObserver.onNext(DeleteDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in Delete", e);
+            responseObserver.onNext(DeleteDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void executeSql(SqlRequest request,
+                           StreamObserver<SqlResponse> responseObserver) {
+        try {
+            Object result;
+            if (request.getResultClass() != null && !request.getResultClass().isEmpty()) {
+                Class<?> clazz = Class.forName(request.getResultClass());
+                result = nucleoDB.sql(request.getSql(), clazz);
+            } else {
+                result = nucleoDB.sql(request.getSql());
+            }
+
+            String resultJson = JsonHelper.toJson(result);
+            responseObserver.onNext(SqlResponse.newBuilder()
+                .setStatus(StatusHelper.success())
+                .setResultJson(resultJson)
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in ExecuteSql", e);
+            responseObserver.onNext(SqlResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void bulkCreate(BulkCreateDataEntryRequest request,
+                           StreamObserver<BulkCreateDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(BulkCreateDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            Class<?> dataClass = table.getConfig().getClazz();
+            Class<?> deClass = table.getConfig().getDataEntryClass();
+
+            List<DataEntryMessage> created = new ArrayList<>();
+            int successCount = 0;
+            int failureCount = 0;
+
+            for (String dataJson : request.getDataJsonListList()) {
+                try {
+                    Object dataObj = JsonHelper.mapper().readValue(dataJson, dataClass);
+                    DataEntry entry;
+                    if (deClass == DataEntry.class) {
+                        entry = new DataEntry(dataObj);
+                    } else {
+                        entry = (DataEntry) deClass
+                            .getDeclaredConstructor(dataClass)
+                            .newInstance(dataObj);
+                    }
+                    table.saveSync(entry);
+                    created.add(JsonHelper.toProto(entry));
+                    successCount++;
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Bulk create item failed", e);
+                    failureCount++;
+                }
+            }
+
+            responseObserver.onNext(BulkCreateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success(
+                    successCount + " created, " + failureCount + " failed"))
+                .addAllEntries(created)
+                .setSuccessCount(successCount)
+                .setFailureCount(failureCount)
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in BulkCreate", e);
+            responseObserver.onNext(BulkCreateDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Override
+    public void bulkDelete(BulkDeleteDataEntryRequest request,
+                           StreamObserver<BulkDeleteDataEntryResponse> responseObserver) {
+        try {
+            DataTable table = nucleoDB.getTable(request.getTable());
+            if (table == null) {
+                responseObserver.onNext(BulkDeleteDataEntryResponse.newBuilder()
+                    .setStatus(StatusHelper.error(StatusHelper.TABLE_NOT_FOUND,
+                        "Table '" + request.getTable() + "' not found"))
+                    .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            int successCount = 0;
+            int failureCount = 0;
+
+            for (String key : request.getKeysList()) {
+                try {
+                    DataEntryProjection projection = new DataEntryProjection();
+                    projection.setWritable(true);
+                    Set<DataEntry> entries = table.get("id", key, projection);
+                    if (entries != null && !entries.isEmpty()) {
+                        table.deleteSync(entries.iterator().next());
+                        successCount++;
+                    } else {
+                        failureCount++;
+                    }
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Bulk delete item failed for key: " + key, e);
+                    failureCount++;
+                }
+            }
+
+            responseObserver.onNext(BulkDeleteDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.success(
+                    successCount + " deleted, " + failureCount + " failed"))
+                .setSuccessCount(successCount)
+                .setFailureCount(failureCount)
+                .build());
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error in BulkDelete", e);
+            responseObserver.onNext(BulkDeleteDataEntryResponse.newBuilder()
+                .setStatus(StatusHelper.error(StatusHelper.INTERNAL_ERROR, e.getMessage()))
+                .build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/util/JsonHelper.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/util/JsonHelper.java
@@ -1,0 +1,59 @@
+package com.nucleodb.grpc.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nucleodb.grpc.proto.ConnectionMessage;
+import com.nucleodb.grpc.proto.DataEntryMessage;
+import com.nucleodb.library.database.tables.connection.Connection;
+import com.nucleodb.library.database.tables.table.DataEntry;
+
+public final class JsonHelper {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private JsonHelper() {}
+
+    public static ObjectMapper mapper() {
+        return MAPPER;
+    }
+
+    public static DataEntryMessage toProto(DataEntry<?> entry) throws JsonProcessingException {
+        DataEntryMessage.Builder builder = DataEntryMessage.newBuilder()
+            .setKey(entry.getKey())
+            .setVersion(entry.getVersion())
+            .setDataJson(MAPPER.writeValueAsString(entry.getData()));
+        if (entry.getCreated() != null) {
+            builder.setCreated(entry.getCreated().toString());
+        }
+        if (entry.getModified() != null) {
+            builder.setModified(entry.getModified().toString());
+        }
+        return builder.build();
+    }
+
+    public static ConnectionMessage toProto(Connection<?, ?> conn) {
+        ConnectionMessage.Builder builder = ConnectionMessage.newBuilder()
+            .setUuid(conn.getUuid())
+            .setFromKey(conn.getFromKey())
+            .setToKey(conn.getToKey())
+            .setVersion(conn.getVersion());
+        if (conn.getMetadata() != null) {
+            builder.putAllMetadata(conn.getMetadata());
+        }
+        if (conn.getDate() != null) {
+            builder.setDate(conn.getDate().toString());
+        }
+        if (conn.getModified() != null) {
+            builder.setModified(conn.getModified().toString());
+        }
+        return builder.build();
+    }
+
+    public static String toJson(Object obj) throws JsonProcessingException {
+        return MAPPER.writeValueAsString(obj);
+    }
+}

--- a/nucleodb-grpc/src/main/java/com/nucleodb/grpc/util/StatusHelper.java
+++ b/nucleodb-grpc/src/main/java/com/nucleodb/grpc/util/StatusHelper.java
@@ -1,0 +1,38 @@
+package com.nucleodb.grpc.util;
+
+import com.nucleodb.grpc.proto.OperationStatus;
+
+public final class StatusHelper {
+
+    private StatusHelper() {}
+
+    public static OperationStatus success() {
+        return OperationStatus.newBuilder()
+            .setSuccess(true)
+            .setMessage("OK")
+            .build();
+    }
+
+    public static OperationStatus success(String message) {
+        return OperationStatus.newBuilder()
+            .setSuccess(true)
+            .setMessage(message)
+            .build();
+    }
+
+    public static OperationStatus error(String errorCode, String message) {
+        return OperationStatus.newBuilder()
+            .setSuccess(false)
+            .setErrorCode(errorCode)
+            .setMessage(message)
+            .build();
+    }
+
+    public static final String TABLE_NOT_FOUND = "TABLE_NOT_FOUND";
+    public static final String CONNECTION_TYPE_NOT_FOUND = "CONNECTION_TYPE_NOT_FOUND";
+    public static final String ENTRY_NOT_FOUND = "ENTRY_NOT_FOUND";
+    public static final String CONNECTION_NOT_FOUND = "CONNECTION_NOT_FOUND";
+    public static final String INVALID_REQUEST = "INVALID_REQUEST";
+    public static final String INTERNAL_ERROR = "INTERNAL_ERROR";
+    public static final String SERIALIZATION_ERROR = "SERIALIZATION_ERROR";
+}

--- a/nucleodb-grpc/src/main/proto/nucleodb/v1/common.proto
+++ b/nucleodb-grpc/src/main/proto/nucleodb/v1/common.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package nucleodb.v1;
+
+option java_multiple_files = true;
+option java_package = "com.nucleodb.grpc.proto";
+option java_outer_classname = "CommonProto";
+
+message Pagination {
+  int64 skip = 1;
+  int64 limit = 2;
+}
+
+message OperationStatus {
+  bool success = 1;
+  string message = 2;
+  string error_code = 3;
+}

--- a/nucleodb-grpc/src/main/proto/nucleodb/v1/connection.proto
+++ b/nucleodb-grpc/src/main/proto/nucleodb/v1/connection.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package nucleodb.v1;
+
+import "nucleodb/v1/common.proto";
+
+option java_multiple_files = true;
+option java_package = "com.nucleodb.grpc.proto";
+option java_outer_classname = "ConnectionProto";
+
+message ConnectionMessage {
+  string uuid = 1;
+  string from_key = 2;
+  string to_key = 3;
+  map<string, string> metadata = 4;
+  int64 version = 5;
+  string date = 6;
+  string modified = 7;
+}
+
+// --- Create ---
+message CreateConnectionRequest {
+  string connection_type = 1;
+  string from_key = 2;
+  string to_key = 3;
+  map<string, string> metadata = 4;
+}
+
+message CreateConnectionResponse {
+  OperationStatus status = 1;
+  ConnectionMessage connection = 2;
+}
+
+// --- Read by UUID ---
+message GetConnectionRequest {
+  string connection_type = 1;
+  string uuid = 2;
+}
+
+message GetConnectionResponse {
+  OperationStatus status = 1;
+  ConnectionMessage connection = 2;
+}
+
+// --- Read by from key ---
+message GetConnectionsByFromRequest {
+  string connection_type = 1;
+  string from_key = 2;
+  Pagination pagination = 3;
+}
+
+message GetConnectionsByFromResponse {
+  OperationStatus status = 1;
+  repeated ConnectionMessage connections = 2;
+}
+
+// --- Read by from+to keys ---
+message GetConnectionsByFromAndToRequest {
+  string connection_type = 1;
+  string from_key = 2;
+  string to_key = 3;
+  Pagination pagination = 4;
+}
+
+message GetConnectionsByFromAndToResponse {
+  OperationStatus status = 1;
+  repeated ConnectionMessage connections = 2;
+}
+
+// --- Reverse lookup by to key ---
+message GetConnectionsByToRequest {
+  string connection_type = 1;
+  string to_key = 2;
+  Pagination pagination = 3;
+}
+
+message GetConnectionsByToResponse {
+  OperationStatus status = 1;
+  repeated ConnectionMessage connections = 2;
+}
+
+// --- Get all connections of a type ---
+message GetAllConnectionsRequest {
+  string connection_type = 1;
+  Pagination pagination = 2;
+}
+
+message GetAllConnectionsResponse {
+  OperationStatus status = 1;
+  repeated ConnectionMessage connections = 2;
+  int64 total_count = 3;
+}
+
+// --- Update ---
+message UpdateConnectionRequest {
+  string connection_type = 1;
+  string uuid = 2;
+  map<string, string> metadata = 3;
+}
+
+message UpdateConnectionResponse {
+  OperationStatus status = 1;
+  ConnectionMessage connection = 2;
+}
+
+// --- Delete ---
+message DeleteConnectionRequest {
+  string connection_type = 1;
+  string uuid = 2;
+}
+
+message DeleteConnectionResponse {
+  OperationStatus status = 1;
+}
+
+// --- Bulk Create ---
+message BulkCreateConnectionRequest {
+  string connection_type = 1;
+  repeated CreateConnectionEntry connections = 2;
+}
+
+message CreateConnectionEntry {
+  string from_key = 1;
+  string to_key = 2;
+  map<string, string> metadata = 3;
+}
+
+message BulkCreateConnectionResponse {
+  OperationStatus status = 1;
+  repeated ConnectionMessage connections = 2;
+  int32 success_count = 3;
+  int32 failure_count = 4;
+}
+
+// --- Bulk Delete ---
+message BulkDeleteConnectionRequest {
+  string connection_type = 1;
+  repeated string uuids = 2;
+}
+
+message BulkDeleteConnectionResponse {
+  OperationStatus status = 1;
+  int32 success_count = 2;
+  int32 failure_count = 3;
+}
+
+service ConnectionService {
+  rpc Create (CreateConnectionRequest) returns (CreateConnectionResponse);
+  rpc Get (GetConnectionRequest) returns (GetConnectionResponse);
+  rpc GetByFrom (GetConnectionsByFromRequest) returns (GetConnectionsByFromResponse);
+  rpc GetByFromAndTo (GetConnectionsByFromAndToRequest) returns (GetConnectionsByFromAndToResponse);
+  rpc GetByTo (GetConnectionsByToRequest) returns (GetConnectionsByToResponse);
+  rpc GetAll (GetAllConnectionsRequest) returns (GetAllConnectionsResponse);
+  rpc Update (UpdateConnectionRequest) returns (UpdateConnectionResponse);
+  rpc Delete (DeleteConnectionRequest) returns (DeleteConnectionResponse);
+  rpc BulkCreate (BulkCreateConnectionRequest) returns (BulkCreateConnectionResponse);
+  rpc BulkDelete (BulkDeleteConnectionRequest) returns (BulkDeleteConnectionResponse);
+}

--- a/nucleodb-grpc/src/main/proto/nucleodb/v1/data_entry.proto
+++ b/nucleodb-grpc/src/main/proto/nucleodb/v1/data_entry.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+package nucleodb.v1;
+
+import "nucleodb/v1/common.proto";
+
+option java_multiple_files = true;
+option java_package = "com.nucleodb.grpc.proto";
+option java_outer_classname = "DataEntryProto";
+
+// Represents a DataEntry as exchanged over the wire.
+message DataEntryMessage {
+  string key = 1;
+  int64 version = 2;
+  string data_json = 3;
+  string created = 4;
+  string modified = 5;
+}
+
+// --- Create ---
+message CreateDataEntryRequest {
+  string table = 1;
+  string data_json = 2;
+}
+
+message CreateDataEntryResponse {
+  OperationStatus status = 1;
+  DataEntryMessage entry = 2;
+}
+
+// --- Read by ID ---
+message GetDataEntryRequest {
+  string table = 1;
+  string key = 2;
+}
+
+message GetDataEntryResponse {
+  OperationStatus status = 1;
+  DataEntryMessage entry = 2;
+}
+
+// --- Read by index key ---
+message GetDataEntriesByIndexRequest {
+  string table = 1;
+  string index_key = 2;
+  string value_json = 3;
+  Pagination pagination = 4;
+}
+
+message GetDataEntriesByIndexResponse {
+  OperationStatus status = 1;
+  repeated DataEntryMessage entries = 2;
+}
+
+// --- Get all entries ---
+message GetAllDataEntriesRequest {
+  string table = 1;
+  Pagination pagination = 2;
+}
+
+message GetAllDataEntriesResponse {
+  OperationStatus status = 1;
+  repeated DataEntryMessage entries = 2;
+  int64 total_count = 3;
+}
+
+// --- Update ---
+message UpdateDataEntryRequest {
+  string table = 1;
+  string key = 2;
+  string data_json = 3;
+}
+
+message UpdateDataEntryResponse {
+  OperationStatus status = 1;
+  DataEntryMessage entry = 2;
+}
+
+// --- Delete ---
+message DeleteDataEntryRequest {
+  string table = 1;
+  string key = 2;
+}
+
+message DeleteDataEntryResponse {
+  OperationStatus status = 1;
+}
+
+// --- SQL Passthrough ---
+message SqlRequest {
+  string sql = 1;
+  string result_class = 2;
+}
+
+message SqlResponse {
+  OperationStatus status = 1;
+  string result_json = 2;
+}
+
+// --- Bulk Create ---
+message BulkCreateDataEntryRequest {
+  string table = 1;
+  repeated string data_json_list = 2;
+}
+
+message BulkCreateDataEntryResponse {
+  OperationStatus status = 1;
+  repeated DataEntryMessage entries = 2;
+  int32 success_count = 3;
+  int32 failure_count = 4;
+}
+
+// --- Bulk Delete ---
+message BulkDeleteDataEntryRequest {
+  string table = 1;
+  repeated string keys = 2;
+}
+
+message BulkDeleteDataEntryResponse {
+  OperationStatus status = 1;
+  int32 success_count = 2;
+  int32 failure_count = 3;
+}
+
+service DataEntryService {
+  rpc Create (CreateDataEntryRequest) returns (CreateDataEntryResponse);
+  rpc Get (GetDataEntryRequest) returns (GetDataEntryResponse);
+  rpc GetByIndex (GetDataEntriesByIndexRequest) returns (GetDataEntriesByIndexResponse);
+  rpc GetAll (GetAllDataEntriesRequest) returns (GetAllDataEntriesResponse);
+  rpc Update (UpdateDataEntryRequest) returns (UpdateDataEntryResponse);
+  rpc Delete (DeleteDataEntryRequest) returns (DeleteDataEntryResponse);
+  rpc ExecuteSql (SqlRequest) returns (SqlResponse);
+  rpc BulkCreate (BulkCreateDataEntryRequest) returns (BulkCreateDataEntryResponse);
+  rpc BulkDelete (BulkDeleteDataEntryRequest) returns (BulkDeleteDataEntryResponse);
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'library'
+
+include 'nucleodb-grpc'


### PR DESCRIPTION
Introduce a new `nucleodb-grpc` Gradle submodule that exposes NucleoDB's
DataTable and Connection APIs over gRPC. The module includes:

- Protobuf service definitions for DataEntryService (9 RPCs: Create, Get,
  GetByIndex, GetAll, Update, Delete, ExecuteSql, BulkCreate, BulkDelete)
  and ConnectionService (10 RPCs: Create, Get, GetByFrom, GetByFromAndTo,
  GetByTo, GetAll, Update, Delete, BulkCreate, BulkDelete)
- Java service implementations wrapping the existing NucleoDB synchronous
  API with in-band error reporting via OperationStatus
- NucleoDBGrpcServer with fluent builder for easy server setup
- Utility classes for JSON/proto conversion and status handling
- Multi-module Gradle setup with protobuf code generation

https://claude.ai/code/session_01Ba1B8yFpXCQuVZEKkbcE8z